### PR TITLE
Fix/pytorch vulnerability update

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           pip install poetry
           poetry install --with dev
       - name: Run ruff
-        run: poetry run ruff .
+        run: poetry run ruff check .
 
   codecov:
     needs: unit_test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pandas = ">= 1"
 Pillow = ">= 8.4.0"
 scikit-learn = ">= 1"
 timm = ">= 0.5.4"
-torch = ">= 1.13.1, <=2.0.0"
+torch = ">2.2.0"
 torchvision = ">= 0.11.3"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ select = [
     "RUF",
 ]
 unfixable = ["B007"]
-ignore = ["E501", "D100", "D103", "D104", "PLR0913", "PLR0915", "PLR2004", "RUF013", "S101", "ANN101"]
+ignore = ["E501", "D100", "D103", "D104", "PLR0912", "PLR0913", "PLR0915", "PLR2004", "RUF013", "S101", "ANN101"]
 
 src = ["aisee", "tests"]
 


### PR DESCRIPTION
- Upgraded PyTorch to version >2.2.0 due to a security vulnerability.
- Changed the ruff command from `poetry run ruff .` to `poetry run ruff check .`
- Ignore the ruff rule PLR0912.